### PR TITLE
[MAKO-2342] Catch all JSON parsing errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,18 @@
 PATH
   remote: .
   specs:
-    trulioo (0.1.0)
-      httparty
+    trulioo (0.2.6)
+      httparty (~> 0.15)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    httparty (0.15.5)
+    httparty (0.19.0)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0901)
     multi_xml (0.6.0)
 
 PLATFORMS
@@ -18,4 +22,4 @@ DEPENDENCIES
   trulioo!
 
 BUNDLED WITH
-   1.15.1
+   1.17.3

--- a/lib/trulioo/api/verifications.rb
+++ b/lib/trulioo/api/verifications.rb
@@ -12,7 +12,7 @@ module Trulioo
 
           # Try parsing the value as JSON
           JSON.parse(value)
-        rescue JSON::ParserError
+        rescue StandardError
           # Return the value if it's not JSON
           value
         end

--- a/trulioo.gemspec
+++ b/trulioo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'trulioo'
-  s.version     = '0.2.5'
+  s.version     = '0.2.6'
   s.date        = '2017-07-11'
   s.summary     = "A Ruby wrapper for Trulioo's GlobalGateway API"
   s.authors     = ['Dave Nguyen']


### PR DESCRIPTION
- Catch all StandardErrors so that we don't raise "cannot convert Array to String" when JSON parsing an array