### PR TITLE
[INFRA-59] replace deprecated URI.encode

### DIFF
--- a/lib/trulioo/connector.rb
+++ b/lib/trulioo/connector.rb
@@ -45,7 +45,7 @@ module Trulioo
     end
 
     def url(namespace, action)
-      URI.encode(
+      URI::Parser.new.escape(
         "#{settings.base_uri}/#{namespace}/#{settings.api_version}/#{action}"
       )
     end

--- a/trulioo.gemspec
+++ b/trulioo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'trulioo'
-  s.version     = '0.2.6'
+  s.version     = '0.2.7'
   s.date        = '2017-07-11'
   s.summary     = "A Ruby wrapper for Trulioo's GlobalGateway API"
   s.authors     = ['Dave Nguyen']


### PR DESCRIPTION
- `URI.encode` is deprecated in Ruby 2.7.8
- This PR replaces it w/ `URI::Parser.new.escape`: https://bootrails.com/blog/how-to-encode-url-string-in-ruby/