### PR TITLE
[PEQ-4581] Allow callers of the ‘Verify’ endpoint to manually configure the request timeout settings

### DIFF
--- a/lib/trulioo/api/verifications.rb
+++ b/lib/trulioo/api/verifications.rb
@@ -32,8 +32,10 @@ module Trulioo
         Result.new(get(action, auth: true))
       end
 
-      def verify(data)
-        Result.new(post('verify', auth: true, body: data))
+      def verify(data, timeout_params = {})
+        options = if timeout_params.present? ? {body: data}.merge(timeout_params) : {body: data}
+
+        Result.new(post('verify', auth: true, options))
       end
 
       private

--- a/lib/trulioo/connector.rb
+++ b/lib/trulioo/connector.rb
@@ -37,11 +37,20 @@ module Trulioo
       }
       params.merge!(auth_params) if options[:auth]
       params[:body] = params_body(options[:body]) if options[:body]
-      params
+      params.merge(timeout_params(params)) if timeout_params(params).present?
     end
 
     def params_body(body)
       { AcceptTruliooTermsAndConditions: true }.merge(body).to_json
+    end
+
+    def timeout_params(params)
+      {
+        timeout: params[:timeout].present? ? params[:timeout] : nil,
+        open_timeout: params[:open_timeout].present? ? params[:open_timeout] : nil,
+        read_timeout: params[:read_timeout].present? ? params[:read_timeout] : nil,
+        write_timeout: params[:write_timeout].present? ? params[:write_timeout] : nil,
+      }.compact
     end
 
     def url(namespace, action)

--- a/trulioo.gemspec
+++ b/trulioo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'trulioo'
-  s.version     = '0.2.7'
+  s.version     = '0.2.8'
   s.date        = '2017-07-11'
   s.summary     = "A Ruby wrapper for Trulioo's GlobalGateway API"
   s.authors     = ['Dave Nguyen']


### PR DESCRIPTION
This PR updates the Trulioo gem so that we can support extending the timeout duration, as explained in more detail here: https://makofintech.atlassian.net/browse/PEQ-4581. This was done by adding an optional `timeout_param`, which lets the caller of the API configure the timeout settings at a granular level. 

Although I believe that the `timeout` parameter will simply overwrite (or act as a default) for the `open_timeout`/`read_timeout`/`write_timeout`, I wasn't able to figure out whether this would mean that each step would use the default-timeout (i.e total-timeout = 3 * default-timeout) or whether it would mean the whole request would be the default-timeout (i.e total-timeout = default-timeout). To keep things flexible so we don't have to keep updating this gem, I just added the option to pass in all three.

Resources:
- https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts/blob/master/README.md 
- https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty%2FClassMethods:open_timeout
- https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty%2FClassMethods:read_timeout
- https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty%2FClassMethods:default_timeout
- https://stackoverflow.com/questions/50444355/how-can-i-increase-timeout-for-httparty-post-method-in-rails