### PR TITLE
[PEQ-4581] Fixed a syntax error which was causing the build to fail

### DIFF
--- a/lib/trulioo/api/verifications.rb
+++ b/lib/trulioo/api/verifications.rb
@@ -33,10 +33,10 @@ module Trulioo
       end
 
       def verify(data, timeout_params = {})
-        options = if timeout_params.present? ? {body: data}.merge(timeout_params) : {body: data}
+      options = timeout_params.present? ? { body: data }.merge(timeout_params) : { body: data }
 
-        Result.new(post('verify', auth: true, options))
-      end
+      Result.new(post("verify", auth: true, **options))
+    end
 
       private
 


### PR DESCRIPTION
There was a syntax error in the `verifications.rb` file, which was causing the build to fail. This should be resolved with this fix, along with a double splat to properly pass in the parameters to the post method call.