### PR TITLE
[PEQ-4581] Rolled back connector and verification changes

### DIFF
--- a/lib/trulioo/api/verifications.rb
+++ b/lib/trulioo/api/verifications.rb
@@ -32,11 +32,9 @@ module Trulioo
         Result.new(get(action, auth: true))
       end
 
-      def verify(data, timeout_params = {})
-      options = timeout_params.present? ? { body: data }.merge(timeout_params) : { body: data }
-
-      Result.new(post("verify", auth: true, **options))
-    end
+      def verify(data)
+        Result.new(post('verify', auth: true, body: data))
+      end
 
       private
 

--- a/lib/trulioo/connector.rb
+++ b/lib/trulioo/connector.rb
@@ -37,20 +37,11 @@ module Trulioo
       }
       params.merge!(auth_params) if options[:auth]
       params[:body] = params_body(options[:body]) if options[:body]
-      params.merge(timeout_params(params)) if timeout_params(params).present?
+      params
     end
 
     def params_body(body)
       { AcceptTruliooTermsAndConditions: true }.merge(body).to_json
-    end
-
-    def timeout_params(params)
-      {
-        timeout: params[:timeout].present? ? params[:timeout] : nil,
-        open_timeout: params[:open_timeout].present? ? params[:open_timeout] : nil,
-        read_timeout: params[:read_timeout].present? ? params[:read_timeout] : nil,
-        write_timeout: params[:write_timeout].present? ? params[:write_timeout] : nil,
-      }.compact
     end
 
     def url(namespace, action)

--- a/trulioo.gemspec
+++ b/trulioo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'trulioo'
-  s.version     = '0.2.8'
+  s.version     = '0.2.9'
   s.date        = '2017-07-11'
   s.summary     = "A Ruby wrapper for Trulioo's GlobalGateway API"
   s.authors     = ['Dave Nguyen']


### PR DESCRIPTION
Realized while testing in staging that I've misplaced the Timeout parameter, it should be in the request-body rather than as a separate element of the request payload. I'm reverting my changes that I've made in the previous PRs and bumping the version to 2.9.