### PR TITLE
[PEQ-4581] Added HTTParty params back in

### DIFF
--- a/lib/trulioo/api/verifications.rb
+++ b/lib/trulioo/api/verifications.rb
@@ -32,8 +32,10 @@ module Trulioo
         Result.new(get(action, auth: true))
       end
 
-      def verify(data)
-        Result.new(post('verify', auth: true, body: data))
+      def verify(data, timeout_params = {})
+        options = timeout_params.present? ? { body: data }.merge(timeout_params) : { body: data }
+        
+        Result.new(post('verify', auth: true, **options))
       end
 
       private

--- a/lib/trulioo/api/verifications.rb
+++ b/lib/trulioo/api/verifications.rb
@@ -32,10 +32,8 @@ module Trulioo
         Result.new(get(action, auth: true))
       end
 
-      def verify(data, timeout_params = {})
-        options = timeout_params.present? ? { body: data }.merge(timeout_params) : { body: data }
-        
-        Result.new(post('verify', auth: true, **options))
+      def verify(data, options = {})
+        Result.new(post('verify', auth: true, body: data, **options))
       end
 
       private

--- a/lib/trulioo/connector.rb
+++ b/lib/trulioo/connector.rb
@@ -50,7 +50,7 @@ module Trulioo
     def timeout_params(options)
       timeout_keys = [:timeout, :open_timeout, :read_timeout, :write_timeout]
       options.slice(*timeout_keys).compact
-   end
+    end
 
     def url(namespace, action)
       URI::Parser.new.escape(

--- a/lib/trulioo/connector.rb
+++ b/lib/trulioo/connector.rb
@@ -35,6 +35,9 @@ module Trulioo
           'Content-Type' => 'application/json'
         }
       }
+      timeout_params = timeout_params(options)
+      params.merge!(timeout_params) if timeout_params.present?
+
       params.merge!(auth_params) if options[:auth]
       params[:body] = params_body(options[:body]) if options[:body]
       params
@@ -43,6 +46,11 @@ module Trulioo
     def params_body(body)
       { AcceptTruliooTermsAndConditions: true }.merge(body).to_json
     end
+
+    def timeout_params(options)
+      timeout_keys = [:timeout, :open_timeout, :read_timeout, :write_timeout]
+      options.slice(*timeout_keys).compact
+   end
 
     def url(namespace, action)
       URI::Parser.new.escape(


### PR DESCRIPTION
Alright ... after reviewing my previous changes @dventulieri was correct, and we'll need to have these back in, as HTTParty will default to a timeout of sixty seconds. The only testing I was able to do for this was locally, where I tested a few different options by manually updating the Gemfile:

```
irb(main):050:0> verifications.verify(request_body, {"timeout": 0.1})
Traceback (most recent call last):
        2: from (irb):49
        1: from (irb):50:in `rescue in irb_binding'
Net::ReadTimeout (Net::ReadTimeout)
```

and: 
```
irb(main):051:0> verifications.verify(request_body, {"timeout": 1})
=> #<Trulioo::API::Verifications::Result:0x000000012ddbc738 @code=200, @response=#<HTTParty::Response:0x11350 parsed_response={"TransactionID"=>"3ec7d78e-872f-44cd-a558-332b4eeb16c8", ...
```

Which seem to suggest that that the timeout parameter is being passed correctly to HTTParty, this should let us override the default timeout. 