### PR TITLE
[PEQ-6050] Updated gem to now point to api.trulioo.com rather than api.globaldatacompany.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem provides access to [Trulioo](https://www.trulioo.com/)'s GlobalGateway
 API. For detailed information regarding the API, check out their [API
-docs](https://api.globaldatacompany.com/docs).
+docs](https://developer.trulioo.com/reference/welcome).
 
 ## Getting Started
 

--- a/lib/trulioo/connector.rb
+++ b/lib/trulioo/connector.rb
@@ -36,7 +36,7 @@ module Trulioo
         }
       }
       timeout_params = timeout_params(options)
-      params.merge!(timeout_params) if timeout_params.present?
+      params.merge!(timeout_params) unless timeout_params.empty?
 
       params.merge!(auth_params) if options[:auth]
       params[:body] = params_body(options[:body]) if options[:body]

--- a/lib/trulioo/settings.rb
+++ b/lib/trulioo/settings.rb
@@ -7,7 +7,7 @@ module Trulioo
 
     def initialize
       @api_version = 'v1'
-      @base_uri = 'https://api.globaldatacompany.com'
+      @base_uri = 'https://api.trulioo.com'
     end
   end
 end

--- a/trulioo.gemspec
+++ b/trulioo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'trulioo'
-  s.version     = '0.2.9'
+  s.version     = '0.2.10'
   s.date        = '2017-07-11'
   s.summary     = "A Ruby wrapper for Trulioo's GlobalGateway API"
   s.authors     = ['Dave Nguyen']

--- a/trulioo.gemspec
+++ b/trulioo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'trulioo'
-  s.version     = '0.2.10'
+  s.version     = '0.2.11'
   s.date        = '2017-07-11'
   s.summary     = "A Ruby wrapper for Trulioo's GlobalGateway API"
   s.authors     = ['Dave Nguyen']


### PR DESCRIPTION
Updates the Gem to point to `api.trulioo.com` instead of `api.globaldatacompany.com`, fixes a small bug and bumps the version of the Gem.